### PR TITLE
BDSGOLD-332. Removing spark core and spark devel dependency

### DIFF
--- a/scripts/justinstall.sh
+++ b/scripts/justinstall.sh
@@ -55,8 +55,6 @@ fpm --verbose \
 --rpm-os linux \
 --architecture all \
 --category "Development/Libraries" \
--d alti-spark-$SPARK_VERSION \
--d alti-spark-$SPARK_VERSION-devel \
 -s dir \
 -t rpm \
 -n ${RPM_NAME} \


### PR DESCRIPTION
Went through the changes with Anil for the rationale.
While I think this change is non-essential as sparkexample needs spark core anyways and spark devel's dependency is snipped from spark core in sparkbuild, I understand the thesis for trimming down the individual rpms.
